### PR TITLE
Create and document npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,9 @@ In `config.js`, your tenant ID should go in the `realm` configuration field.
 
 ### Step 6: Run the application
 
-* `$ node app.js`
-
-**Is the server output hard to understand?:** We use `bunyan` for logging in this sample. The console won't make much sense to you unless you also install bunyan and run the server like above but pipe it through the bunyan binary:
-
-* `$ npm install -g bunyan`
-* `$ node app.js | bunyan`
+```bash
+$ npm start
+```
 
 ### You're done!
 

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
         "assert-plus": "~1.0.0",
         "passport": "~0.3.2",
         "passport-azure-ad": "~1.4.4"
+    },
+    "scripts": {
+        "start": "node app.js | bunyan"
     }
 }


### PR DESCRIPTION
Hi,

thanks for a valuable example of getting Azure/OpenId and Node.js up-n-running!

These small changes mainly fixes one thing; adds a `npm start` script making it easier to start the server.

*P.S. as `bunyan` already is a dependency, there's no need for the developer to install that explicitly, as `./node_modules/.bin` is put into `$PATH` automatically for npm scripts.*